### PR TITLE
Fix: Don't need to add ES key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: Add ES package key
-  apt_key:
-    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    keyring: /etc/apt/trusted.gpg.d/elasticsearch-keyring.gpg
+# - name: Add ES package key
+#   apt_key:
+#     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+#     keyring: /etc/apt/trusted.gpg.d/elasticsearch-keyring.gpg
 
 - name: Add ES repository
   apt_repository:


### PR DESCRIPTION
The es key is no more necessary (but I don't remember why)